### PR TITLE
[add] 職務経歴書詳細画面を実装

### DIFF
--- a/app/frontend/stylesheets/base.scss
+++ b/app/frontend/stylesheets/base.scss
@@ -26,6 +26,7 @@ a {
   border: 1px solid $base-color;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
 
   &__white {

--- a/app/frontend/stylesheets/resumes/show.scss
+++ b/app/frontend/stylesheets/resumes/show.scss
@@ -1,0 +1,142 @@
+@import '../base.scss';
+
+.resume-detail {
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 0 20px;
+
+  &__header {
+    text-align: center;
+    margin-bottom: 40px;
+  }
+
+  &__title {
+    font-size: 32px;
+    color: $base-color;
+    margin-bottom: 20px;
+    font-weight: bold;
+  }
+
+  &__guest-notice {
+    background-color: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+
+    .guest-notice__text {
+      color: #495057;
+      margin-bottom: 10px;
+      line-height: 1.6;
+    }
+  }
+
+  &__content {
+    background-color: white;
+    border: 1px solid #e9ecef;
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    margin-bottom: 30px;
+  }
+
+  &__section {
+    margin-bottom: 30px;
+    padding-bottom: 25px;
+    border-bottom: 1px solid #f2f2f2;
+
+    &:last-child {
+      border-bottom: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  &__section-icon {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    margin-right: 10px;
+    vertical-align: middle;
+    color: $base-color;
+  }
+
+  &__section-title {
+    display: inline-block;
+    font-size: 18px;
+    color: $base-color;
+    font-weight: bold;
+    margin-bottom: 15px;
+    vertical-align: middle;
+  }
+
+  &__section-content {
+    font-size: 16px;
+    color: #333;
+    line-height: 1.8;
+    padding-left: 42px;
+  }
+
+  &__summary {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 12px;
+    padding: 30px;
+    margin-bottom: 30px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  &__summary-title {
+    font-size: 20px;
+    color: white;
+    font-weight: bold;
+    margin-bottom: 15px;
+  }
+
+  &__summary-content {
+    font-size: 16px;
+    color: white;
+    line-height: 1.8;
+    background-color: rgba(255, 255, 255, 0.1);
+    padding: 20px;
+    border-radius: 8px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 15px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .resume-detail {
+    &__title {
+      font-size: 24px;
+    }
+
+    &__content {
+      padding: 20px;
+    }
+
+    &__section-content {
+      padding-left: 0;
+      margin-top: 10px;
+    }
+
+    &__summary {
+      padding: 20px;
+    }
+
+    &__actions {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 15px;
+
+      .base-btn {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  }
+}

--- a/app/views/resumes/show.html.slim
+++ b/app/views/resumes/show.html.slim
@@ -1,0 +1,48 @@
+.resume-detail
+  .resume-detail__header
+    h1.resume-detail__title
+    - if @user.is_a?(Guest)
+      .resume-detail__guest-notice
+        p.guest-notice__text
+          | ゲストユーザーとして作成した職務経歴書です
+        p.guest-notice__text
+          | アカウント登録をすると、複数の職務経歴書を作成・管理できるようになります
+        div(style="display: flex; justify-content: center;")
+          = link_to "アカウント登録", signup_path, class: "base-btn"
+
+  .resume-detail__summary
+    h2.resume-detail__summary-title 文章化した職務経歴
+    .resume-detail__summary-content
+      = @resume.generate_summary
+
+  .resume-detail__content
+    .resume-detail__section
+      .resume-detail__section-icon
+        #CompanyIcon
+      h2.resume-detail__section-title 会社名・役職
+      .resume-detail__section-content
+        = "#{@resume.company} / #{@resume.position}"
+
+    .resume-detail__section
+      .resume-detail__section-icon
+        #BriefcaseIcon
+      h2.resume-detail__section-title やったこと
+      .resume-detail__section-content
+        = simple_format(@resume.tasks)
+
+    .resume-detail__section
+      .resume-detail__section-icon
+        #LightbulbIcon
+      h2.resume-detail__section-title 工夫したこと
+      .resume-detail__section-content
+        = simple_format(@resume.improvements)
+
+    .resume-detail__section
+      .resume-detail__section-icon
+        #ChartLineIcon
+      h2.resume-detail__section-title 成果・実績
+      .resume-detail__section-content
+        = simple_format(@resume.achievements)
+
+  .resume-detail__actions(style="display: flex;")
+    = link_to "トップページへ戻る", root_path, class: "base-btn base-btn__white"


### PR DESCRIPTION
- 会社名と役職を統合して表示
- 文章化した職務経歴を上部に配置
- レスポンシブ対応（SPサイズでボタンを縦並び）
- ボタンのテキスト中央揃えを修正

🤖 Generated with [Claude Code](https://claude.ai/code)